### PR TITLE
Add security gate and dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+
+registries:
+  github-packages:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    username: ${{ secrets.CLOUD_AUTOMATION_USER }}
+    password: ${{secrets.CLOUD_AUTOMATION_ACCESS_TOKEN_READONLY}}
+
+updates:
+  # Enable version updates for npm/yarn dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries:
+      - github-packages
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    # Open pull requests for version updates
+    open-pull-requests-limit: 10
+    # Commit message preferences
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    # Group minor and patch updates together
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Enable version updates for Docker dependencies
+  - package-ecosystem: "docker"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    # Open pull requests for version updates
+    open-pull-requests-limit: 5
+    # Commit message preferences
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    # Open pull requests for version updates
+    open-pull-requests-limit: 5
+    # Commit message preferences
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    # Ignore reusable workflows from private repository that Dependabot can't access
+    ignore:
+      - dependency-name: "Zonos/github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
     username: ${{ secrets.CLOUD_AUTOMATION_USER }}
-    password: ${{secrets.CLOUD_AUTOMATION_ACCESS_TOKEN_READONLY}}
+    password: ${{ secrets.CLOUD_AUTOMATION_ACCESS_TOKEN_READONLY }}
 
 updates:
   # Enable version updates for npm/yarn dependencies
@@ -31,20 +31,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
-  # Enable version updates for Docker dependencies
-  - package-ecosystem: "docker"
-    directory: "/.github"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    # Open pull requests for version updates
-    open-pull-requests-limit: 5
-    # Commit message preferences
-    commit-message:
-      prefix: "docker"
-      include: "scope"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
This PR adds **Dependabot** configuration for automated dependency updates.

## What does the Dependabot config do?

The `dependabot.yml` configures GitHub Dependabot to automatically open PRs for dependency updates:

- **Package dependencies**: Weekly on Mondays, minor and patch updates grouped
- **Docker base images**: Weekly on Mondays
- **GitHub Actions versions**: Weekly on Mondays

**Critical and high severity** Dependabot PRs should be reviewed and merged promptly, as unresolved critical/high alerts will block production deployments via our security gate initiative.

For more context, see the [Security Gate documentation](https://myzonos.atlassian.net/wiki/x/BYDI1).

## Changes
- `.github/dependabot.yml`: New file for automated dependency update configuration

## Test plan
- [ ] Verify PR builds successfully

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Dependabot configuration only; the main impact is increased automated PR noise and potential reliance on GitHub secrets/registry access for private npm packages.
> 
> **Overview**
> Adds `.github/dependabot.yml` to enable weekly automated dependency update PRs.
> 
> Configures Dependabot to scan `npm` dependencies (using the GitHub Packages registry, grouping minor/patch updates, and limiting PR volume) and `github-actions` versions, while ignoring `Zonos/github-actions` reusable workflows that Dependabot can’t access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00e781469e466ddab4dd1982ea2d58ea9b90ef17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->