### PR TITLE
DEV-1021: Add Datadog service catalog definition

### DIFF
--- a/.github/service.datadog.yaml
+++ b/.github/service.datadog.yaml
@@ -1,0 +1,33 @@
+apiVersion: v3
+kind: service
+metadata:
+  name: commerce
+  owner: team-19
+  additionalOwners:
+    - name: devops
+      type: infra
+  tags:
+    - language:typescript
+    - cloud_provider:aws
+  contacts:
+    - name: team-19-checkout
+      type: slack
+      contact: https://zonos.slack.com/archives/C07TVDT9058
+  links:
+    - name: Source Code
+      type: repo
+      url: https://github.com/Zonos/commerce
+      provider: github
+spec:
+  lifecycle: production
+  tier: "bronze"
+  type: web
+  languages:
+    - typescript
+datadog:
+  codeLocations:
+    - repositoryURL: https://github.com/Zonos/commerce
+extensions:
+  datadoghq.com/ci-pipelines:
+    - name: commerce
+      provider: github


### PR DESCRIPTION
## Summary

- Adds `.github/service.datadog.yaml` (v3 schema) for the Datadog Software Catalog
- Sets service owner to `team-19` with `devops` as infra co-owner
- Includes Slack contact, repo link, language tags, tier, and lifecycle metadata

## Test plan

- [ ] Verify yaml renders correctly in Datadog Software Catalog after merge
- [ ] Confirm team ownership shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds metadata-only YAML for Datadog catalog/CI pipeline linkage with no runtime code changes.
> 
> **Overview**
> Adds `.github/service.datadog.yaml` (Datadog Software Catalog v3) defining the `commerce` service’s ownership, contacts, tags, lifecycle/tier, repo link, and CI pipeline metadata for Datadog integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8b1cddeb6ecb75fcfe4328b00d94e9ff1b72442. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->